### PR TITLE
feat: 可选的 AI 答疑气泡(opt-in,默认关闭)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,6 @@ BYRDOCS_SITE_URL=https://byrdocs.org
 PUBLISH_SITE_URL=https://publish.byrdocs.org
 # 你的 byrdocs-archive 对应的 GitHub 仓库
 ARCHIVE_REPO_URL=https://github.com/byrdocs/byrdocs-archive
+# 可选:AI 答疑气泡的后端地址(superdocs-agent)。留空=不启用,右下角不出现气泡。
+# 例:VITE_CHAT_EMBED_URL=https://byrdocs.cloudlay.cn
+VITE_CHAT_EMBED_URL=

--- a/src/components/chat-bubble.tsx
+++ b/src/components/chat-bubble.tsx
@@ -1,0 +1,21 @@
+import { useEffect } from "react";
+
+/**
+ * 可选的 AI 答疑气泡:仅当配置了 VITE_CHAT_EMBED_URL 时加载,否则完全不出现。
+ * 聊天 / AI / 登录等全部在该 URL 指向的独立后端(/app/*),本组件只注入一行加载器;
+ * 加载器在 Shadow DOM 里建悬浮气泡 + iframe,样式与本站完全隔离。
+ */
+export function ChatBubble() {
+  const base = import.meta.env.VITE_CHAT_EMBED_URL as string | undefined;
+  useEffect(() => {
+    if (!base || document.getElementById("sd-agent-widget-loader")) return;
+    const s = document.createElement("script");
+    s.id = "sd-agent-widget-loader";
+    s.src = base.replace(/\/$/, "") + "/app/widget.js";
+    s.defer = true;
+    s.setAttribute("data-accent", "#2563eb");
+    s.setAttribute("data-position", "bottom-right");
+    document.body.appendChild(s);
+  }, [base]);
+  return null;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -14,6 +14,7 @@ import Notfound from './pages/Notfound';
 import Home from './pages/Home';
 import Loading from './components/loading';
 import { SsrProvider, readSsrBootstrap } from './ssr-context';
+import { ChatBubble } from './components/chat-bubble';
 
 const About = lazy(() => import('./pages/About'))
 const Callback = lazy(() => import('./pages/Callback'))
@@ -71,6 +72,7 @@ const app = (
       <ThemeProvider defaultTheme="system">
         <RouterProvider router={router} />
         <Toaster position="bottom-center" richColors={true} />
+        <ChatBubble />
       </ThemeProvider>
     </SsrProvider>
   </React.StrictMode>


### PR DESCRIPTION
嗨~ 给站里加了个可选的 AI 答疑小气泡,默认关着,先发上来给你们看看实现。

**是啥**:右下角一个浮动气泡,点开是聊天框,基于咱们的资料库答疑(查不到就联网兜底、带来源)。已经在我维护的国内镜像 byrdocs.cloudlay.cn 上跑着,可以直接点右下角试。

**怎么实现的(尽量不打扰现有代码)**
- 网站这边只多了一个组件 `ChatBubble` + 一个环境变量 `VITE_CHAT_EMBED_URL`。**不配这个变量,组件直接 `return null`,气泡完全不出现**——合了也不影响现状,想开再开。
- 组件唯一干的事:往页面插一行 `<script src="<后端>/app/widget.js">`。这个 loader 在 **Shadow DOM** 里建气泡 + 一个 `<iframe>` 加载聊天 UI,样式和脚本跟站点**完全隔离**,不会跟 Radix/Tailwind 打架。
- **聊天、流式、AI、登录这些重活全在独立后端**(`/app/*`,开源:[superdocs-agent](https://github.com/Jinchen-Yang/superdocs-agent)),网站只管挂个壳。不碰 Worker、不碰鉴权/数据、不引第三方 CDN 库、不动 CORS、不破坏 SSR。
- 登录:用户在气泡里用学号 + 统一认证登一次,后端自己签会话,**网站这边不掺和、不持任何密钥**。

**改动就三处**
- `src/components/chat-bubble.tsx`(新增)
- `src/main.tsx` 应用树里挂一行 `<ChatBubble />`
- `.env.example` 加个变量说明

**浏览器**:Chrome / Edge 完整可用(用了 Partitioned/CHIPS cookie);Safari / Firefox 因为第三方 cookie 收得严,跨域内嵌时可能每次得现登一下(功能在,体验打折)。要根治也行:给后端挂个 byrdocs 自己的子域(比如 `ai.byrdocs.org`),跟主站同注册域就不算第三方了,Safari 那点事全没——只要加一条 DNS CNAME 指到现有服务器,你们不用建服务器也不用运维,纯可选。

觉得行就这样,想改名/改位置/改默认色都好说。子域那个方便就给,不方也行,不影响主体。